### PR TITLE
Feature/resolve stackoverflow

### DIFF
--- a/src/main/groovy/sitimi/Computer.groovy
+++ b/src/main/groovy/sitimi/Computer.groovy
@@ -30,9 +30,6 @@ class Computer {
     }
 
     private checkParameters = {method, args ->
-        if(args.isEmpty()){
-            return true
-        }
         try{
             method.checkParameters(args.collect { it.class }.toArray(new Class[args.size()]))
         }catch(IllegalArgumentException e){

--- a/src/main/groovy/sitimi/Computer.groovy
+++ b/src/main/groovy/sitimi/Computer.groovy
@@ -23,7 +23,6 @@ class Computer {
     }
 
     private hasMethod = {o, name, args ->
-        println args
         if( 1 <= o.metaClass.getMethods().findAll { it.name == name}.count { checkParameters(it, args) } ){
             return true
         }


### PR DESCRIPTION
# このプルリクエストをマージすると
* 236b58b5f48cebe994c610e4dde7e3c817317804 で誤って混入した不要なprintがされなくなります
* パラメータが0個の時にスタックオーバーフローする問題が解消します