### PR TITLE
add report screen capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,12 @@ class SimpleCalcSpec extends SitimiSpec{
 # Operation
 
 The methods provided by Sikuli's Screen(org.sikuli.script.Screen) can be used as is
+
+# Report
+
+
+When SitimiReportingSpec is inherited, screen capture is automatically reported at the end of the test and at the time of failure.
+You can also use the report (label) method to get a capture anywhere.
+
+
+The captured file is output to `build/reports/tests/evidences` .

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'java'
 apply plugin: "groovy"
 apply plugin: 'idea'
 
-version = '0.0.1'
+version = '0.0.2'
 group = 'sitimi'
 
 

--- a/src/main/groovy/sitimi/Computer.groovy
+++ b/src/main/groovy/sitimi/Computer.groovy
@@ -87,6 +87,13 @@ class Computer {
         App.open a.path
     }
 
+    def capture(file){
+        def dir = new File('build/reports/tests/evidences')
+        if( ! dir.exists())dir.mkdirs()
+        def image = getScreen().capture()// Screen as SikuliX
+        new File("${file}.png", dir) << new File(image.getFile()).getBytes()
+    }
+
     private <T extends Application> T createApplication(Class<T> clazz){
         clazz.newInstance().init(this)
     }

--- a/src/main/groovy/sitimi/spock/OnFailureReporter.groovy
+++ b/src/main/groovy/sitimi/spock/OnFailureReporter.groovy
@@ -1,0 +1,28 @@
+package sitimi.spock
+
+import org.spockframework.runtime.AbstractRunListener
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.ErrorInfo
+
+import static org.spockframework.runtime.model.MethodKind.FEATURE
+
+class OnFailureReporter extends AbstractRunListener implements IMethodInterceptor {
+
+    private SitimiReportingSpec spec
+
+    void intercept(IMethodInvocation invocation) throws Throwable {
+        spec = invocation.instance
+        invocation.proceed()
+    }
+
+    void error(ErrorInfo error) {
+        if (error.method.kind == FEATURE) {
+            try {
+                spec.reportFailure()
+            } catch (Exception e) {
+                //ignore
+            }
+        }
+    }
+}

--- a/src/main/groovy/sitimi/spock/ReportingOnFailureExtension.groovy
+++ b/src/main/groovy/sitimi/spock/ReportingOnFailureExtension.groovy
@@ -1,0 +1,23 @@
+package sitimi.spock
+
+import org.spockframework.runtime.extension.IGlobalExtension
+import org.spockframework.runtime.model.SpecInfo
+
+class ReportingOnFailureExtension implements IGlobalExtension {
+
+    @Override
+    void start() {
+    }
+
+    @Override
+    void stop() {
+    }
+
+    void visitSpec(SpecInfo spec) {
+        if (SitimiReportingSpec.isAssignableFrom(spec.reflection)) {
+            def reporter = new OnFailureReporter()
+            spec.addListener(reporter)
+            spec.allFeatures*.addIterationInterceptor(reporter)
+        }
+    }
+}

--- a/src/main/groovy/sitimi/spock/SitimiReportingSpec.groovy
+++ b/src/main/groovy/sitimi/spock/SitimiReportingSpec.groovy
@@ -1,0 +1,35 @@
+package sitimi.spock
+
+import org.junit.Rule
+import org.junit.rules.TestName
+import spock.lang.Shared
+
+class SitimiReportingSpec extends SitimiSpec{
+    @Rule
+    TestName specTestName
+    private int perTestCounter = 1
+    @Shared
+    private int specTestCounter = 1
+
+    def cleanup() {
+        report('end')
+        ++specTestCounter
+    }
+
+    void report(String label = "") {
+        getComputer().capture(createReportLabel(label))
+    }
+
+    void reportFailure() {
+        report('failure')
+    }
+
+    String createReportLabel(String label = ""){
+        toTestReportLabel(specTestCounter, perTestCounter++, specTestName?.methodName ?: 'fixture', label)
+    }
+
+    static String toTestReportLabel(int testCounter, int reportCounter, String methodName, String label) {
+        def numberFormat = "%03d"
+        "${String.format(numberFormat, testCounter)}-${String.format(numberFormat, reportCounter)}-$methodName-$label"
+    }
+}

--- a/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/src/main/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,1 @@
+sitimi.spock.ReportingOnFailureExtension

--- a/src/test/groovy/SimpleCalcSpec.groovy
+++ b/src/test/groovy/SimpleCalcSpec.groovy
@@ -1,8 +1,8 @@
 import app.Calc
 import app.CalcWindow
-import sitimi.spock.SitimiSpec
+import sitimi.spock.SitimiReportingSpec
 
-class SimpleCalcSpec extends SitimiSpec{
+class SimpleCalcSpec extends SitimiReportingSpec{
     def cleanup(){
         "ウィンドウを閉じる"()
     }


### PR DESCRIPTION
# このプルリクエストをマージすると
* 画面キャプチャの取得が可能になります

SitimiReportingSpecを継承することでテストの終了と失敗時に自動でキャプチャが取得されます
また report(label) を使用すると任意の箇所でキャプチャが取得できます

# 注意事項
* 画像の形式はpngです
* gebにある失敗時だけキャプチャするオプションはありません
* キャプチャしたファイルはbuild/reports/tests/evidences に出力されます
* マイナーバージョンをあげます